### PR TITLE
Refactor parallelism such that each partition-batch is its own task that...

### DIFF
--- a/src/main/java/io/ifar/archive/ArchiveApplication.java
+++ b/src/main/java/io/ifar/archive/ArchiveApplication.java
@@ -68,7 +68,7 @@ public class ArchiveApplication extends Application<ArchiveConfiguration> {
         }
 
         ArchiveListener listener = new ArchiveListener(s3Client, configuration.getS3Configuration(),
-                configuration.getSeedBrokers(), workUnitPath, kafkaMessagePartitioner);
+                configuration.getSeedBrokers(), workUnitPath, kafkaMessagePartitioner, configuration.getMaxNumParallelWorkers());
         environment.lifecycle().manage(listener);
 
         ClusterConfig clusterConfig = new ClusterConfig()

--- a/src/main/java/io/ifar/archive/ArchiveConfiguration.java
+++ b/src/main/java/io/ifar/archive/ArchiveConfiguration.java
@@ -36,6 +36,9 @@ public class ArchiveConfiguration extends Configuration {
     @JsonProperty
     private Map<String, DateRegexMessagePartitionerConfig> kafkaMessagePartitionerConfig;
 
+    @JsonProperty
+    int maxNumParallelWorkers = 16;
+
     public String getServiceName() {
         return serviceName;
     }
@@ -56,5 +59,9 @@ public class ArchiveConfiguration extends Configuration {
 
     public Map<String, DateRegexMessagePartitionerConfig> getKafkaMessagePartitionerConfig() {
         return kafkaMessagePartitionerConfig;
+    }
+
+    public int getMaxNumParallelWorkers() {
+        return maxNumParallelWorkers;
     }
 }


### PR DESCRIPTION
... is scheduled by an executor service, rather than each partition being a persistent self-managing thread that loops over batches.

ArchiverWorker becomes an object that manages partition ZK state and Kafka broker connections across many serially-executing scheduled tasks (ArchiveBatchWorker).

This simplifies the design and allows us to control the degree of parallelism by sizing the thread pool.

It appears to perform far better than the old version. I ran it for a day on a single m3.medium with 16 threads and it caught up on several days of archiving in a few hours while staying under 50% CPU util.
